### PR TITLE
[pt-PT] Improved both .AFF files for AO45 and AO90

### DIFF
--- a/data/spelling-dict/hunspell/pt_PT_45.aff
+++ b/data/spelling-dict/hunspell/pt_PT_45.aff
@@ -589,7 +589,20 @@ SFX v   ar              áveis           ar              +CAT=adj,G=_,N=p,FSEM=ve
 SFX v   er              íveis           er              +CAT=adj,G=_,N=p,FSEM=vel
 SFX v   ir              íveis           ir              +CAT=adj,G=_,N=p,FSEM=vel
 
-SFX X Y 161
+SFX X Y 174
+SFX X   r       -me            [aei]r
+SFX X   r       -te            [aei]r
+SFX X   r       -se            [ae]r
+SFX X   r       -se-lhe        [ae]r
+SFX X   r       -se-lhes       [ae]r
+SFX X   r       -nos           [ae]r
+SFX X   r       -vos           [ae]r
+SFX X   r       -lhe           [ae]r
+SFX X   r       -lhes          [ae]r
+SFX X   r       -a             [aei]r
+SFX X   r       -as            [aei]r
+SFX X   r       -o             [aei]r
+SFX X   r       -os            [aei]r
 SFX X   ar              o               [^-]ar          +P=1,N=s,T=p
 SFX X   r               s               ar              +P=2,N=s,T=p
 SFX X   ar              a               [^-]ar          +P=3,N=s,T=p

--- a/data/spelling-dict/hunspell/pt_PT_90.aff
+++ b/data/spelling-dict/hunspell/pt_PT_90.aff
@@ -631,7 +631,20 @@ SFX v   ar              áveis           ar              +CAT=adj,G=_,N=p,FSEM=ve
 SFX v   er              íveis           er              +CAT=adj,G=_,N=p,FSEM=vel
 SFX v   ir              íveis           ir              +CAT=adj,G=_,N=p,FSEM=vel
 
-SFX X Y 161
+SFX X Y 174
+SFX X   r       -me            [aei]r
+SFX X   r       -te            [aei]r
+SFX X   r       -se            [ae]r
+SFX X   r       -se-lhe        [ae]r
+SFX X   r       -se-lhes       [ae]r
+SFX X   r       -nos           [ae]r
+SFX X   r       -vos           [ae]r
+SFX X   r       -lhe           [ae]r
+SFX X   r       -lhes          [ae]r
+SFX X   r       -a             [aei]r
+SFX X   r       -as            [aei]r
+SFX X   r       -o             [aei]r
+SFX X   r       -os            [aei]r
 SFX X   ar              o               [^-]ar          +P=1,N=s,T=p
 SFX X   r               s               ar              +P=2,N=s,T=p
 SFX X   ar              a               [^-]ar          +P=3,N=s,T=p


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart 

Like I said yesterday, I will do this task bit by bit to make sure I won't screw up.

So, here is an improvement for verb forms of the kind:
```
ama-a
ama-as
ama-lhe
ama-lhes
ama-me
ama-nos
ama-o
ama-os
ama-se
ama-se-lhe
ama-se-lhes
ama-te
ama-vos
```

NEW WORDS (AO45):
[3.PTPT_45_new_verbs.txt](https://github.com/languagetool-org/portuguese-pos-dict/files/14093809/3.PTPT_45_new_verbs.txt)


NEW WORDS (AO90):
[6.PTPT_90_new_verbs.txt](https://github.com/languagetool-org/portuguese-pos-dict/files/14093810/6.PTPT_90_new_verbs.txt)


PS→ Moments ago I forgot to create a Pull Request, so in the Git software I selected to amend it and repulled it.