### PR TITLE
[pt-PT] Improved .AFF files for both AO45 and AO90

### DIFF
--- a/data/spelling-dict/hunspell/pt_PT_45.aff
+++ b/data/spelling-dict/hunspell/pt_PT_45.aff
@@ -589,20 +589,33 @@ SFX v   ar              áveis           ar              +CAT=adj,G=_,N=p,FSEM=ve
 SFX v   er              íveis           er              +CAT=adj,G=_,N=p,FSEM=vel
 SFX v   ir              íveis           ir              +CAT=adj,G=_,N=p,FSEM=vel
 
-SFX X Y 174
-SFX X   r       -me            [aei]r
-SFX X   r       -te            [aei]r
-SFX X   r       -se            [ae]r
-SFX X   r       -se-lhe        [ae]r
-SFX X   r       -se-lhes       [ae]r
-SFX X   r       -nos           [ae]r
-SFX X   r       -vos           [ae]r
-SFX X   r       -lhe           [ae]r
-SFX X   r       -lhes          [ae]r
-SFX X   r       -a             [aei]r
-SFX X   r       -as            [aei]r
-SFX X   r       -o             [aei]r
-SFX X   r       -os            [aei]r
+SFX X Y 187
+SFX X   ar               e-me           [^cgç]ar
+SFX X   ar               e-te           [^cgç]ar
+SFX X   ar               e-se           [^cgç]ar
+SFX X   ar               e-se-lhe       [^cgç]ar
+SFX X   ar               e-se-lhes      [^cgç]ar
+SFX X   ar               e-nos          [^cgç]ar
+SFX X   ar               e-vos          [^cgç]ar
+SFX X   ar               e-lhe          [^cgç]ar
+SFX X   ar               e-lhes         [^cgç]ar
+SFX X   ar               e-a            [^cgç]ar
+SFX X   ar               e-as           [^cgç]ar
+SFX X   ar               e-o            [^cgç]ar
+SFX X   ar               e-os           [^cgç]ar
+SFX X   r               -me             [aei]r
+SFX X   r               -te             [aei]r
+SFX X   r               -se             [ae]r
+SFX X   r               -se-lhe         [ae]r
+SFX X   r               -se-lhes        [ae]r
+SFX X   r               -nos            [ae]r
+SFX X   r               -vos            [ae]r
+SFX X   r               -lhe            [ae]r
+SFX X   r               -lhes           [ae]r
+SFX X   r               -a              [aei]r
+SFX X   r               -as             [aei]r
+SFX X   r               -o              [aei]r
+SFX X   r               -os             [aei]r
 SFX X   ar              o               [^-]ar          +P=1,N=s,T=p
 SFX X   r               s               ar              +P=2,N=s,T=p
 SFX X   ar              a               [^-]ar          +P=3,N=s,T=p

--- a/data/spelling-dict/hunspell/pt_PT_90.aff
+++ b/data/spelling-dict/hunspell/pt_PT_90.aff
@@ -631,20 +631,33 @@ SFX v   ar              áveis           ar              +CAT=adj,G=_,N=p,FSEM=ve
 SFX v   er              íveis           er              +CAT=adj,G=_,N=p,FSEM=vel
 SFX v   ir              íveis           ir              +CAT=adj,G=_,N=p,FSEM=vel
 
-SFX X Y 174
-SFX X   r       -me            [aei]r
-SFX X   r       -te            [aei]r
-SFX X   r       -se            [ae]r
-SFX X   r       -se-lhe        [ae]r
-SFX X   r       -se-lhes       [ae]r
-SFX X   r       -nos           [ae]r
-SFX X   r       -vos           [ae]r
-SFX X   r       -lhe           [ae]r
-SFX X   r       -lhes          [ae]r
-SFX X   r       -a             [aei]r
-SFX X   r       -as            [aei]r
-SFX X   r       -o             [aei]r
-SFX X   r       -os            [aei]r
+SFX X Y 187
+SFX X   ar               e-me           [^cgç]ar
+SFX X   ar               e-te           [^cgç]ar
+SFX X   ar               e-se           [^cgç]ar
+SFX X   ar               e-se-lhe       [^cgç]ar
+SFX X   ar               e-se-lhes      [^cgç]ar
+SFX X   ar               e-nos          [^cgç]ar
+SFX X   ar               e-vos          [^cgç]ar
+SFX X   ar               e-lhe          [^cgç]ar
+SFX X   ar               e-lhes         [^cgç]ar
+SFX X   ar               e-a            [^cgç]ar
+SFX X   ar               e-as           [^cgç]ar
+SFX X   ar               e-o            [^cgç]ar
+SFX X   ar               e-os           [^cgç]ar
+SFX X   r               -me             [aei]r
+SFX X   r               -te             [aei]r
+SFX X   r               -se             [ae]r
+SFX X   r               -se-lhe         [ae]r
+SFX X   r               -se-lhes        [ae]r
+SFX X   r               -nos            [ae]r
+SFX X   r               -vos            [ae]r
+SFX X   r               -lhe            [ae]r
+SFX X   r               -lhes           [ae]r
+SFX X   r               -a              [aei]r
+SFX X   r               -as             [aei]r
+SFX X   r               -o              [aei]r
+SFX X   r               -os             [aei]r
 SFX X   ar              o               [^-]ar          +P=1,N=s,T=p
 SFX X   r               s               ar              +P=2,N=s,T=p
 SFX X   ar              a               [^-]ar          +P=3,N=s,T=p


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart 

I hope to have committed to the right branch this time.

This commit adds verbal forms such as:
```
ame-a
ame-as
ame-lhe
ame-lhes
ame-me
ame-nos
ame-o
ame-os
ame-se
ame-se-lhe
ame-se-lhes
ame-te
ame-vos
```

But in AO90 it added 58465 words, could you give a quick look to check if everything is fine? It is crazy to have so many new words since the dictionaries are maintained by Minho University for decades and from one moment to the other it raises 58 thousand words?

AO45:
[3.PTPT_45_new_verbs.txt](https://github.com/languagetool-org/portuguese-pos-dict/files/14134967/3.PTPT_45_new_verbs.txt)


AO90:
[6.PTPT_90_new_verbs.txt](https://github.com/languagetool-org/portuguese-pos-dict/files/14134974/6.PTPT_90_new_verbs.txt)


😛 😛 😛 😛 😛 😛 😛 😛 😛 

Thanks!

