### PR TITLE
[pt-PT] Added rules to AO45 and AO90 .AFFs

### DIFF
--- a/data/spelling-dict/hunspell/pt_PT_45.aff
+++ b/data/spelling-dict/hunspell/pt_PT_45.aff
@@ -1349,7 +1349,7 @@ SFX L   0               -vos-iam        r               +AP=2,AN=p,P=3,N=p,T=c
 SFX L   0               -vos-ia         r               +AP=2,AN=p,P=1_3,N=s,T=c
 SFX L   0               -vos-ias        r               +AP=2,AN=p,P=2,N=s,T=c
 
-SFX P Y 239
+SFX P Y 263
 SFX P   erer            é-la            querer
 SFX P   erer            é-las           querer
 SFX P   erer            é-lo            querer
@@ -1417,6 +1417,22 @@ SFX P   er              ê-lo            er              +G=m,N=s
 SFX P   er              ê-la            er              +G=f,N=s
 SFX P   er              ê-los           er              +G=m,N=p
 SFX P   er              ê-las           er              +G=f,N=p
+SFX P   er              ê-la-á          [^mr][^abrs]ter              +P=3,N=s,T=f
+SFX P   er              ê-la-ás         [^mr][^abrs]ter              +P=2,N=s,T=f
+SFX P   er              ê-la-ão         [^mr][^abrs]ter              +P=3,N=p,T=f
+SFX P   er              ê-la-ia         [^mr][^abrs]ter              +P=1_3,N=s,T=c
+SFX P   er              ê-la-ias        [^mr][^abrs]ter              +P=2,N=s,T=c
+SFX P   er              ê-la-íamos      [^mr][^abrs]ter              +P=1,N=p,T=c
+SFX P   er              ê-la-iam        [^mr][^abrs]ter              +P=3,N=p,T=c
+SFX P   er              ê-las-á         [^mr][^abrs]ter              +P=3,N=s,T=f
+SFX P   er              ê-las-ás        [^mr][^abrs]ter              +P=2,N=s,T=f
+SFX P   er              ê-las-ei        [^mr][^abrs]ter              +P=1,N=s,T=f
+SFX P   er              ê-las-eis       [^mr][^abrs]ter              +P=2,N=p,T=f
+SFX P   er              ê-las-ão        [^mr][^abrs]ter              +P=3,N=p,T=f
+SFX P   er              ê-las-ia        [^mr][^abrs]ter              +P=1_3,N=s,T=c
+SFX P   er              ê-las-ias       [^mr][^abrs]ter              +P=2,N=s,T=c
+SFX P   er              ê-las-íamos     [^mr][^abrs]ter              +P=1,N=p,T=c
+SFX P   er              ê-las-iam       [^mr][^abrs]ter              +P=3,N=p,T=c
 SFX P   er              ê-lo-ei         er              +P=1,N=s,T=f
 SFX P   er              ê-lo-ás         er              +P=2,N=s,T=f
 SFX P   er              ê-lo-á          er              +P=3,N=s,T=f
@@ -1428,6 +1444,14 @@ SFX P   er              ê-lo-ias        er              +P=2,N=s,T=c
 SFX P   er              ê-lo-íamos      er              +P=1,N=p,T=c
 SFX P   er              ê-lo-íeis       er              +P=2,N=p,T=c
 SFX P   er              ê-lo-iam        er              +P=3,N=p,T=c
+SFX P   er              ê-los-á         [^mr][^abrs]ter              +P=3,N=s,T=f
+SFX P   er              ê-los-ei        [^mr][^abrs]ter              +P=1,N=s,T=f
+SFX P   er              ê-los-eis       [^mr][^abrs]ter              +P=2,N=p,T=f
+SFX P   er              ê-los-ão        [^mr][^abrs]ter              +P=3,N=p,T=f
+SFX P   er              ê-los-ia        [^mr][^abrs]ter              +P=1_3,N=s,T=c
+SFX P   er              ê-los-ias       [^mr][^abrs]ter              +P=2,N=s,T=c
+SFX P   er              ê-los-íamos     [^mr][^abrs]ter              +P=1,N=p,T=c
+SFX P   er              ê-los-iam       [^mr][^abrs]ter              +P=3,N=p,T=c
 SFX P   zer             -lo          dizer           +P=1,N=s,T=f
 SFX P   zer             -la          dizer           +P=1,N=s,T=f
 SFX P   zer             -los          dizer           +P=1,N=s,T=f

--- a/data/spelling-dict/hunspell/pt_PT_90.aff
+++ b/data/spelling-dict/hunspell/pt_PT_90.aff
@@ -1394,7 +1394,7 @@ SFX L   0               -vos-iam        r               +AP=2,AN=p,P=3,N=p,T=c
 SFX L   0               -vos-ia         r               +AP=2,AN=p,P=1_3,N=s,T=c
 SFX L   0               -vos-ias        r               +AP=2,AN=p,P=2,N=s,T=c
 
-SFX P Y 239
+SFX P Y 263
 SFX P   erer            é-la            querer
 SFX P   erer            é-las           querer
 SFX P   erer            é-lo            querer
@@ -1462,6 +1462,22 @@ SFX P   er              ê-lo            er              +G=m,N=s
 SFX P   er              ê-la            er              +G=f,N=s
 SFX P   er              ê-los           er              +G=m,N=p
 SFX P   er              ê-las           er              +G=f,N=p
+SFX P   er              ê-la-á          [^mr][^abrs]ter              +P=3,N=s,T=f
+SFX P   er              ê-la-ás         [^mr][^abrs]ter              +P=2,N=s,T=f
+SFX P   er              ê-la-ão         [^mr][^abrs]ter              +P=3,N=p,T=f
+SFX P   er              ê-la-ia         [^mr][^abrs]ter              +P=1_3,N=s,T=c
+SFX P   er              ê-la-ias        [^mr][^abrs]ter              +P=2,N=s,T=c
+SFX P   er              ê-la-íamos      [^mr][^abrs]ter              +P=1,N=p,T=c
+SFX P   er              ê-la-iam        [^mr][^abrs]ter              +P=3,N=p,T=c
+SFX P   er              ê-las-á         [^mr][^abrs]ter              +P=3,N=s,T=f
+SFX P   er              ê-las-ás        [^mr][^abrs]ter              +P=2,N=s,T=f
+SFX P   er              ê-las-ei        [^mr][^abrs]ter              +P=1,N=s,T=f
+SFX P   er              ê-las-eis       [^mr][^abrs]ter              +P=2,N=p,T=f
+SFX P   er              ê-las-ão        [^mr][^abrs]ter              +P=3,N=p,T=f
+SFX P   er              ê-las-ia        [^mr][^abrs]ter              +P=1_3,N=s,T=c
+SFX P   er              ê-las-ias       [^mr][^abrs]ter              +P=2,N=s,T=c
+SFX P   er              ê-las-íamos     [^mr][^abrs]ter              +P=1,N=p,T=c
+SFX P   er              ê-las-iam       [^mr][^abrs]ter              +P=3,N=p,T=c
 SFX P   er              ê-lo-ei         er              +P=1,N=s,T=f
 SFX P   er              ê-lo-ás         er              +P=2,N=s,T=f
 SFX P   er              ê-lo-á          er              +P=3,N=s,T=f
@@ -1473,6 +1489,14 @@ SFX P   er              ê-lo-ias        er              +P=2,N=s,T=c
 SFX P   er              ê-lo-íamos      er              +P=1,N=p,T=c
 SFX P   er              ê-lo-íeis       er              +P=2,N=p,T=c
 SFX P   er              ê-lo-iam        er              +P=3,N=p,T=c
+SFX P   er              ê-los-á         [^mr][^abrs]ter              +P=3,N=s,T=f
+SFX P   er              ê-los-ei        [^mr][^abrs]ter              +P=1,N=s,T=f
+SFX P   er              ê-los-eis       [^mr][^abrs]ter              +P=2,N=p,T=f
+SFX P   er              ê-los-ão        [^mr][^abrs]ter              +P=3,N=p,T=f
+SFX P   er              ê-los-ia        [^mr][^abrs]ter              +P=1_3,N=s,T=c
+SFX P   er              ê-los-ias       [^mr][^abrs]ter              +P=2,N=s,T=c
+SFX P   er              ê-los-íamos     [^mr][^abrs]ter              +P=1,N=p,T=c
+SFX P   er              ê-los-iam       [^mr][^abrs]ter              +P=3,N=p,T=c
 SFX P   zer             -lo          dizer           +P=1,N=s,T=f
 SFX P   zer             -la          dizer           +P=1,N=s,T=f
 SFX P   zer             -los          dizer           +P=1,N=s,T=f


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart 

Here is a tiny verbs addition since it only adds 72 words (better short but good than large and wrong):

```
contê-la-á
contê-la-ão
contê-la-ás
contê-la-ia
contê-la-iam
contê-la-íamos
contê-la-ias
contê-las-á
contê-las-ão
contê-las-ás
contê-las-ei
contê-las-eis
contê-las-ia
contê-las-iam
contê-las-íamos
contê-las-ias
contê-los-á
contê-los-ão
contê-los-ei
contê-los-eis
contê-los-ia
contê-los-iam
contê-los-íamos
contê-los-ias
detê-la-á
detê-la-ão
detê-la-ás
detê-la-ia
detê-la-iam
detê-la-íamos
detê-la-ias
detê-las-á
detê-las-ão
detê-las-ás
detê-las-ei
detê-las-eis
detê-las-ia
detê-las-iam
detê-las-íamos
detê-las-ias
detê-los-á
detê-los-ão
detê-los-ei
detê-los-eis
detê-los-ia
detê-los-iam
detê-los-íamos
detê-los-ias
mantê-la-á
mantê-la-ão
mantê-la-ás
mantê-la-ia
mantê-la-iam
mantê-la-íamos
mantê-la-ias
mantê-las-á
mantê-las-ão
mantê-las-ás
mantê-las-ei
mantê-las-eis
mantê-las-ia
mantê-las-iam
mantê-las-íamos
mantê-las-ias
mantê-los-á
mantê-los-ão
mantê-los-ei
mantê-los-eis
mantê-los-ia
mantê-los-iam
mantê-los-íamos
mantê-los-ias
```

They all exist in the pt-BR wordlist, so they should be valid.

The ones that were not in the pt-BR wordlist I checked with ChatGPT:
```
> Sim, todas essas formas verbais existem em português de Portugal. Elas são conjugações do verbo "conter" nas formas do futuro e do condicional, seguidas de pronomes átonos (a, as, o, os, lhe, etc.) para indicar a quem ou o que se está contendo. Aqui estão as conjugações completas: BLAH BLAH
contê-la-ão
contê-la-ás
contê-la-ias
contê-las-ão
contê-las-ás
contê-las-eis
contê-las-ias
contê-los-ão
contê-los-eis
contê-los-ias
========
> Sim, todas essas formas verbais também existem em português de Portugal. Elas são conjugações do verbo "manter" nas formas do futuro e do condicional, seguidas de pronomes átonos para indicar a quem ou o que se está mantendo. Aqui estão as conjugações completas: BLAH BLAH
mantê-la-ão
mantê-la-ás
mantê-la-ias
mantê-las-ão
mantê-las-ás
mantê-las-eis
mantê-las-ias
mantê-los-ão
mantê-los-eis
mantê-los-ias
==========
Sim, todas as formas verbais que você apresentou ("detê-la-ão", "detê-la-ás", "detê-la-ias", "detê-las-ão", "detê-las-ás", "detê-las-eis", "detê-las-ias", "detê-los-ão", "detê-los-eis", "detê-los-ias") são válidas em português de Portugal. Elas são conjugações do verbo "deter" seguido de pronomes átonos para indicar a quem ou o que se está detendo.  BLAH BLAH
detê-la-ão
detê-la-ás
detê-la-ias
detê-las-ão
detê-las-ás
detê-las-eis
detê-las-ias
detê-los-ão
detê-los-eis
detê-los-ias
==================
```
