### PR TITLE
[pt-PT] Improved AFFs of AO45 and AO90

### DIFF
--- a/data/spelling-dict/hunspell/pt_PT_45.aff
+++ b/data/spelling-dict/hunspell/pt_PT_45.aff
@@ -1349,7 +1349,7 @@ SFX L   0               -vos-iam        r               +AP=2,AN=p,P=3,N=p,T=c
 SFX L   0               -vos-ia         r               +AP=2,AN=p,P=1_3,N=s,T=c
 SFX L   0               -vos-ias        r               +AP=2,AN=p,P=2,N=s,T=c
 
-SFX P Y 263
+SFX P Y 287
 SFX P   erer            é-la            querer
 SFX P   erer            é-las           querer
 SFX P   erer            é-lo            querer
@@ -1413,6 +1413,30 @@ SFX P   ar              á-lo-ias        ar              +P=2,N=s,T=c
 SFX P   ar              á-lo-íamos      ar              +P=1,N=p,T=c
 SFX P   ar              á-lo-íeis       ar              +P=2,N=p,T=c
 SFX P   ar              á-lo-iam        ar              +P=3,N=p,T=c
+SFX P   er              ê-la-á          [^a]bater              +P=3,N=s,T=f
+SFX P   er              ê-la-ás         [^a]bater              +P=2,N=s,T=f
+SFX P   er              ê-la-ão         [^a]bater              +P=3,N=p,T=f
+SFX P   er              ê-la-ia         [^a]bater              +P=1_3,N=s,T=c
+SFX P   er              ê-la-ias        [^a]bater              +P=2,N=s,T=c
+SFX P   er              ê-la-íamos      [^a]bater              +P=1,N=p,T=c
+SFX P   er              ê-la-iam        [^a]bater              +P=3,N=p,T=c
+SFX P   er              ê-las-á         [^a]bater              +P=3,N=s,T=f
+SFX P   er              ê-las-ás        [^a]bater              +P=2,N=s,T=f
+SFX P   er              ê-las-ei        [^a]bater              +P=1,N=s,T=f
+SFX P   er              ê-las-eis       [^a]bater              +P=2,N=p,T=f
+SFX P   er              ê-las-ão        [^a]bater              +P=3,N=p,T=f
+SFX P   er              ê-las-ia        [^a]bater              +P=1_3,N=s,T=c
+SFX P   er              ê-las-ias       [^a]bater              +P=2,N=s,T=c
+SFX P   er              ê-las-íamos     [^a]bater              +P=1,N=p,T=c
+SFX P   er              ê-las-iam       [^a]bater              +P=3,N=p,T=c
+SFX P   er              ê-los-á         [^a]bater              +P=3,N=s,T=f
+SFX P   er              ê-los-ei        [^a]bater              +P=1,N=s,T=f
+SFX P   er              ê-los-eis       [^a]bater              +P=2,N=p,T=f
+SFX P   er              ê-los-ão        [^a]bater              +P=3,N=p,T=f
+SFX P   er              ê-los-ia        [^a]bater              +P=1_3,N=s,T=c
+SFX P   er              ê-los-ias       [^a]bater              +P=2,N=s,T=c
+SFX P   er              ê-los-íamos     [^a]bater              +P=1,N=p,T=c
+SFX P   er              ê-los-iam       [^a]bater              +P=3,N=p,T=c
 SFX P   er              ê-lo            er              +G=m,N=s
 SFX P   er              ê-la            er              +G=f,N=s
 SFX P   er              ê-los           er              +G=m,N=p

--- a/data/spelling-dict/hunspell/pt_PT_90.aff
+++ b/data/spelling-dict/hunspell/pt_PT_90.aff
@@ -1394,7 +1394,7 @@ SFX L   0               -vos-iam        r               +AP=2,AN=p,P=3,N=p,T=c
 SFX L   0               -vos-ia         r               +AP=2,AN=p,P=1_3,N=s,T=c
 SFX L   0               -vos-ias        r               +AP=2,AN=p,P=2,N=s,T=c
 
-SFX P Y 263
+SFX P Y 287
 SFX P   erer            é-la            querer
 SFX P   erer            é-las           querer
 SFX P   erer            é-lo            querer
@@ -1458,6 +1458,30 @@ SFX P   ar              á-lo-ias        ar              +P=2,N=s,T=c
 SFX P   ar              á-lo-íamos      ar              +P=1,N=p,T=c
 SFX P   ar              á-lo-íeis       ar              +P=2,N=p,T=c
 SFX P   ar              á-lo-iam        ar              +P=3,N=p,T=c
+SFX P   er              ê-la-á          [^a]bater              +P=3,N=s,T=f
+SFX P   er              ê-la-ás         [^a]bater              +P=2,N=s,T=f
+SFX P   er              ê-la-ão         [^a]bater              +P=3,N=p,T=f
+SFX P   er              ê-la-ia         [^a]bater              +P=1_3,N=s,T=c
+SFX P   er              ê-la-ias        [^a]bater              +P=2,N=s,T=c
+SFX P   er              ê-la-íamos      [^a]bater              +P=1,N=p,T=c
+SFX P   er              ê-la-iam        [^a]bater              +P=3,N=p,T=c
+SFX P   er              ê-las-á         [^a]bater              +P=3,N=s,T=f
+SFX P   er              ê-las-ás        [^a]bater              +P=2,N=s,T=f
+SFX P   er              ê-las-ei        [^a]bater              +P=1,N=s,T=f
+SFX P   er              ê-las-eis       [^a]bater              +P=2,N=p,T=f
+SFX P   er              ê-las-ão        [^a]bater              +P=3,N=p,T=f
+SFX P   er              ê-las-ia        [^a]bater              +P=1_3,N=s,T=c
+SFX P   er              ê-las-ias       [^a]bater              +P=2,N=s,T=c
+SFX P   er              ê-las-íamos     [^a]bater              +P=1,N=p,T=c
+SFX P   er              ê-las-iam       [^a]bater              +P=3,N=p,T=c
+SFX P   er              ê-los-á         [^a]bater              +P=3,N=s,T=f
+SFX P   er              ê-los-ei        [^a]bater              +P=1,N=s,T=f
+SFX P   er              ê-los-eis       [^a]bater              +P=2,N=p,T=f
+SFX P   er              ê-los-ão        [^a]bater              +P=3,N=p,T=f
+SFX P   er              ê-los-ia        [^a]bater              +P=1_3,N=s,T=c
+SFX P   er              ê-los-ias       [^a]bater              +P=2,N=s,T=c
+SFX P   er              ê-los-íamos     [^a]bater              +P=1,N=p,T=c
+SFX P   er              ê-los-iam       [^a]bater              +P=3,N=p,T=c
 SFX P   er              ê-lo            er              +G=m,N=s
 SFX P   er              ê-la            er              +G=f,N=s
 SFX P   er              ê-los           er              +G=m,N=p


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart 

I have improved the AFFs.

It adds near 100 conjugations, not much, but at least they are all valid.

```
combatê-la-á
combatê-la-ão
combatê-la-ás
combatê-la-ia
combatê-la-iam
combatê-la-íamos
combatê-la-ias
combatê-las-á
combatê-las-ão
combatê-las-ás
combatê-las-ei
combatê-las-eis
combatê-las-ia
combatê-las-iam
combatê-las-íamos
combatê-las-ias
combatê-los-á
combatê-los-ão
combatê-los-ei
combatê-los-eis
combatê-los-ia
combatê-los-iam
combatê-los-íamos
combatê-los-ias
debatê-la-á
debatê-la-ão
debatê-la-ás
debatê-la-ia
debatê-la-iam
debatê-la-íamos
debatê-la-ias
debatê-las-á
debatê-las-ão
debatê-las-ás
debatê-las-ei
debatê-las-eis
debatê-las-ia
debatê-las-iam
debatê-las-íamos
debatê-las-ias
debatê-los-á
debatê-los-ão
debatê-los-ei
debatê-los-eis
debatê-los-ia
debatê-los-iam
debatê-los-íamos
debatê-los-ias
esbatê-la-á
esbatê-la-ão
esbatê-la-ás
esbatê-la-ia
esbatê-la-iam
esbatê-la-íamos
esbatê-la-ias
esbatê-las-á
esbatê-las-ão
esbatê-las-ás
esbatê-las-ei
esbatê-las-eis
esbatê-las-ia
esbatê-las-iam
esbatê-las-íamos
esbatê-las-ias
esbatê-los-á
esbatê-los-ão
esbatê-los-ei
esbatê-los-eis
esbatê-los-ia
esbatê-los-iam
esbatê-los-íamos
esbatê-los-ias
rebatê-la-á
rebatê-la-ão
rebatê-la-ás
rebatê-la-ia
rebatê-la-iam
rebatê-la-íamos
rebatê-la-ias
rebatê-las-á
rebatê-las-ão
rebatê-las-ás
rebatê-las-ei
rebatê-las-eis
rebatê-las-ia
rebatê-las-iam
rebatê-las-íamos
rebatê-las-ias
rebatê-los-á
rebatê-los-ão
rebatê-los-ei
rebatê-los-eis
rebatê-los-ia
rebatê-los-iam
rebatê-los-íamos
rebatê-los-ias
```


Missing in pt-BR with ChatGPT help:
```
Estas formas verbais existem em português de Portugal?: "combatê-la-ão","combatê-la-íamos","combatê-la-ias","combatê-las-ão","combatê-las-eis","combatê-las-íamos","combatê-las-ias","combatê-los-ão","combatê-los-eis","combatê-los-íamos","combatê-los-ias"

Sim, as formas verbais que você apresentou existem em português de Portugal. Elas correspondem a conjugações do verbo "combater" em diferentes tempos verbais e modos, utilizando pronomes átonos para indicar o objeto direto da ação ("o", "a", "os", "as").
=========

Estas formas verbais existem em português de Portugal?: "debatê-la-ão","debatê-la-íamos","debatê-la-ias","debatê-las-ão","debatê-las-eis","debatê-las-íamos","debatê-las-ias","debatê-los-ão","debatê-los-eis","debatê-los-íamos","debatê-los-ias"

Sim, todas essas formas verbais são corretas em português de Portugal. Elas correspondem a conjugações do verbo "debaater" em diferentes tempos verbais e modos, usando pronomes átonos para indicar o objeto direto da ação ("o", "a", "os", "as").

=========

Estas formas verbais existem em português de Portugal?: "rebatê-la-ão","rebatê-la-íamos","rebatê-la-ias","rebatê-las-ão","rebatê-las-eis","rebatê-las-íamos","rebatê-las-ias","rebatê-los-ão","rebatê-los-eis","rebatê-los-íamos","rebatê-los-ias"

Sim, todas essas formas verbais são corretas em português de Portugal. Elas correspondem a conjugações do verbo "rebatê-la" e "rebatê-las" em diferentes tempos verbais e modos, utilizando pronomes átonos para indicar o objeto direto da ação ("o", "a", "os", "as").
```