### PR TITLE
[pt] Added postags to numerals-lt.txt

### DIFF
--- a/data/src-dict/numerals-lt.txt
+++ b/data/src-dict/numerals-lt.txt
@@ -13,6 +13,8 @@ duzentas	duzentos	Z0FP0
 duzentos	duzentos	Z0MP0
 mil	mil	Z0CP0
 milhão	milhão	Z0MS0
+milhar	milhar	Z0MS0
+milhares	milhar	Z0MP0
 nove	nove	Z0CP0
 novecentas	novecentos	Z0FP0
 novecentos	novecentos	Z0MP0


### PR DESCRIPTION
Heya, @susanaboatto and @p-goulart ,

Did I edit the correct file?

“milhar” and “milhares” are missing as Z0.+ so I have added them.

I found out they were missing while trying to create an antipattern.


❤️ ❤️ ❤️ ❤️ ❤️ ❤️ 