### PR TITLE
Accept 'email' alongside 'e-mail'

### DIFF
--- a/data/spelling-dict/hunspell/compounds/pt_PT_45.dic
+++ b/data/spelling-dict/hunspell/compounds/pt_PT_45.dic
@@ -1,4 +1,4 @@
-2225
+2224
 abaixo-assinado/pl
 á-bê-cê/pl
 abelha-mestra/ph
@@ -663,8 +663,7 @@ zé-ninguém
 zé-pereira
 zé-povinho
 CD-ROM/þ
-e-mail
-e-mails
+e-mail/þ
 MS-DOS
 Aix-en-Provence
 Aix-la-Chapelle

--- a/data/spelling-dict/hunspell/compounds/pt_PT_90.dic
+++ b/data/spelling-dict/hunspell/compounds/pt_PT_90.dic
@@ -675,8 +675,7 @@ zé-ninguém
 zé-pereira
 zé-povinho
 CD-ROM/þ
-e-mail
-e-mails
+e-mail/þ
 MS-DOS
 Aix-en-Provence
 Aix-la-Chapelle

--- a/data/spelling-dict/hunspell/pt_BR.dic
+++ b/data/spelling-dict/hunspell/pt_BR.dic
@@ -1,4 +1,4 @@
-262033
+262038
 oogaboogatestword
 oogaboogatestwordBR
 o/B
@@ -262036,3 +262036,4 @@ HOP
 oncolítica/D
 viroterapia/B
 autotune
+email/þ

--- a/data/spelling-dict/hunspell/pt_PT_45.dic
+++ b/data/spelling-dict/hunspell/pt_PT_45.dic
@@ -1,4 +1,4 @@
-59633
+59667
 oogaboogatestword
 oogaboogatestwordPT
 oogaboogatestwordPT45
@@ -32964,8 +32964,7 @@ cibernauta/p
 Cobol
 CVS
 DOS
-email
-emails
+email/þ
 escalável/pd
 Ethernet
 Firefox

--- a/data/spelling-dict/hunspell/pt_PT_90.dic
+++ b/data/spelling-dict/hunspell/pt_PT_90.dic
@@ -1,4 +1,4 @@
-60724
+60758
 oogaboogatestword
 oogaboogatestwordPT
 oogaboogatestwordPT90
@@ -33750,8 +33750,7 @@ cibernauta/p
 Cobol
 CVS
 DOS
-email
-emails
+email/þ
 escalável/pd
 Ethernet
 Firefox


### PR DESCRIPTION
Just adding `email` to `pt-BR` alongside `e-mail` (per decision made in #27). This will need to be accompanied by a change to the XML rule `EMAIL_SEM_HIFEN_ORTHOGRAPHY`.