### PR TITLE
Fix bug with local POM version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
     env:
-      LT_BRANCH: "pt/dict/v1.1.0"
+      LT_BRANCH: "pt/dict/v1.2.0"
     steps:
     - name: Set paths
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,12 @@ jobs:
       - name: Set dictionary version
         run: echo "PT_DICT_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//g')" >> $GITHUB_ENV
 
+      - name: Add dictionary version to package pom
+        run: |
+          poetry run python "dict_tools/scripts/update_pom.py" \
+            --new-version "${{ env.PT_DICT_VERSION }}" \
+            --package-name "portuguese-pos-dict"
+
       - name: Set up JDK 11 for x64
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
The release workflow doesn't replace the version of the artifact in the artifact's own POM file. This PR adds an extra step to the SonaType deployment step in the GH workflow to force the version into `pom.xml`.

Addresses #44.