### PR TITLE
[pt-PT] Added words to dictionaries AO45 and AO90

### DIFF
--- a/data/spelling-dict/hunspell/pt_PT_45.dic
+++ b/data/spelling-dict/hunspell/pt_PT_45.dic
@@ -1,4 +1,4 @@
-60042
+60050
 oogaboogatestword
 oogaboogatestwordPT
 oogaboogatestwordPT45
@@ -57397,7 +57397,7 @@ Foucault
 Elizangelas
 Chantal
 Ornithomimosauria
-Red
+Red/þ
 Roger
 Fouto
 Junar
@@ -57945,7 +57945,7 @@ Cerner
 Ophélia
 Phylloxeridae
 Deltacoronavirus
-Blue
+Blue/þ
 Barack
 Verdafero
 Guis
@@ -60041,3 +60041,11 @@ spinning
 Bronx
 Queens
 Wyoming
+subóptimo/fp
+zé-ninguém
+zés-ninguém
+boid/p
+simplificadamente
+fingerprint/þ
+Balikó
+raw

--- a/data/spelling-dict/hunspell/pt_PT_45.dic
+++ b/data/spelling-dict/hunspell/pt_PT_45.dic
@@ -1,4 +1,4 @@
-60050
+60048
 oogaboogatestword
 oogaboogatestwordPT
 oogaboogatestwordPT45
@@ -60042,8 +60042,6 @@ Bronx
 Queens
 Wyoming
 subóptimo/fp
-zé-ninguém
-zés-ninguém
 boid/p
 simplificadamente
 fingerprint/þ

--- a/data/spelling-dict/hunspell/pt_PT_90.dic
+++ b/data/spelling-dict/hunspell/pt_PT_90.dic
@@ -1,4 +1,4 @@
-61140
+61148
 oogaboogatestword
 oogaboogatestwordPT
 oogaboogatestwordPT90
@@ -58488,7 +58488,7 @@ Foucault
 Elizangelas
 Chantal
 Ornithomimosauria
-Red
+Red/þ
 Roger
 Fouto
 Junar
@@ -59036,7 +59036,7 @@ Cerner
 Ophélia
 Phylloxeridae
 Deltacoronavirus
-Blue
+Blue/þ
 Barack
 Verdafero
 Guis
@@ -61139,3 +61139,11 @@ spinning
 Bronx
 Queens
 Wyoming
+subótimo/fp
+zé-ninguém
+zés-ninguém
+boid/p
+simplificadamente
+fingerprint/þ
+Balikó
+raw

--- a/data/spelling-dict/hunspell/pt_PT_90.dic
+++ b/data/spelling-dict/hunspell/pt_PT_90.dic
@@ -1,4 +1,4 @@
-61148
+61146
 oogaboogatestword
 oogaboogatestwordPT
 oogaboogatestwordPT90
@@ -61140,8 +61140,6 @@ Bronx
 Queens
 Wyoming
 subótimo/fp
-zé-ninguém
-zés-ninguém
 boid/p
 simplificadamente
 fingerprint/þ


### PR DESCRIPTION
Heya, @p-goulart ,

I have added a few words.

Notice that “Reds” and “Blues” are used in the military, and “boid” and “boids” are technical terms used in the first well-known agents' simulator.

I haven't checked for morphologic information since I would get too stressed… I will leave morphologic as a low-priority for now, since it is more important to have the words to not appear as typos.